### PR TITLE
version change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-nozzle",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-nozzle",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "generate json-schema from typescript source code and management it",
   "scripts": {
     "clean": "just --config ./.configs/just.config.ts clean",

--- a/src/cli/commands/addOnDatabaseCluster.ts
+++ b/src/cli/commands/addOnDatabaseCluster.ts
@@ -30,7 +30,7 @@ export default async function addOnDatabaseCluster(
   baseOption: TAddSchemaBaseOption,
 ): Promise<void> {
   try {
-    const workerSize = baseOption.maxWorkers ?? os.cpus().length;
+    const workerSize = baseOption.maxWorkers ?? os.cpus().length - 1;
     populate(workerSize).forEach(() => workers.add(cluster.fork()));
 
     spinner.start('TypeScript project loading, ...');

--- a/src/cli/commands/refreshOnDatabaseCluster.ts
+++ b/src/cli/commands/refreshOnDatabaseCluster.ts
@@ -28,7 +28,7 @@ const log = logger();
 
 export default async function refreshOnDatabaseCluster(baseOption: TRefreshSchemaBaseOption) {
   try {
-    const workerSize = baseOption.maxWorkers ?? os.cpus().length;
+    const workerSize = baseOption.maxWorkers ?? os.cpus().length - 1;
     populate(workerSize).forEach(() => workers.add(cluster.fork()));
 
     spinner.start('TypeScript source code compile, ...');


### PR DESCRIPTION
* version change: 0.15.0 > 0.16.0
* max worker size change
  * `os.cpus().length - 1`: remain 1 worker for master