### PR TITLE
Performace tunning: enhance performance more than 60%

### DIFF
--- a/src/cli/commands/addOnDatabaseCluster.ts
+++ b/src/cli/commands/addOnDatabaseCluster.ts
@@ -157,12 +157,6 @@ export default async function addOnDatabaseCluster(
 
     await workers.wait();
 
-    workers.sendAll({
-      command: CE_WORKER_ACTION.GENERATOR_OPTION_LOAD,
-    } satisfies Extract<TMasterToWorkerMessage, { command: typeof CE_WORKER_ACTION.GENERATOR_OPTION_LOAD }>);
-
-    reply = await workers.wait();
-
     // master check generator option loading
     if (reply.data.some((workerReply) => workerReply.result === 'fail')) {
       const failReplies = reply.data.filter(isFailTaskComplete);

--- a/src/cli/commands/addOnDatabaseSync.ts
+++ b/src/cli/commands/addOnDatabaseSync.ts
@@ -17,6 +17,7 @@ import type IDatabaseItem from '#modules/interfaces/IDatabaseItem';
 import summarySchemaFiles from '#modules/summarySchemaFiles';
 import summarySchemaTypes from '#modules/summarySchemaTypes';
 import { isError } from 'my-easy-fp';
+import * as tjsg from 'ts-json-schema-generator';
 
 export default async function addOnDatabaseSync(baseOption: TAddSchemaBaseOption): Promise<void> {
   try {
@@ -54,13 +55,15 @@ export default async function addOnDatabaseSync(baseOption: TAddSchemaBaseOption
     option.types = selectedTypes.pass.map((exportedType) => exportedType.identifier);
     const schemaTypes = await summarySchemaTypes(project.pass, option, schemaFiles.filter);
 
+    const generator = tjsg.createGenerator(option.generatorOptionObject);
+
     const items = schemaTypes
       .map((selectedType) => {
-        const schema = createJSONSchema(
-          selectedType.filePath,
-          selectedType.identifier,
-          option.generatorOptionObject,
-        );
+        const schema = createJSONSchema({
+          filePath: selectedType.filePath,
+          exportedType: selectedType.identifier,
+          generator,
+        });
 
         if (schema.type === 'fail') {
           return undefined;

--- a/src/cli/commands/refreshOnDatabaseCluster.ts
+++ b/src/cli/commands/refreshOnDatabaseCluster.ts
@@ -144,26 +144,28 @@ export default async function refreshOnDatabaseCluster(baseOption: TRefreshSchem
 
     workers.sendAll({ command: CE_WORKER_ACTION.TERMINATE });
 
-    if (atOrThrow(passes, 0).command === CE_WORKER_ACTION.CREATE_JSON_SCHEMA_BULK) {
-      const pass = passes as Extract<
-        TPassWorkerToMasterTaskComplete,
-        { command: typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA_BULK }
-      >[];
-      const db = await openDatabase(option);
-      const newDb = mergeDatabaseItems(db, pass.map((item) => item.data.pass).flat());
+    if (passes.length > 0) {
+      if (atOrThrow(passes, 0).command === CE_WORKER_ACTION.CREATE_JSON_SCHEMA_BULK) {
+        const pass = passes as Extract<
+          TPassWorkerToMasterTaskComplete,
+          { command: typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA_BULK }
+        >[];
+        const db = await openDatabase(option);
+        const newDb = mergeDatabaseItems(db, pass.map((item) => item.data.pass).flat());
 
-      await saveDatabase(option, newDb);
-    } else {
-      log.trace(`reply::: ${JSON.stringify(passes.map((items) => items.data).flat())}`);
+        await saveDatabase(option, newDb);
+      } else {
+        log.trace(`reply::: ${JSON.stringify(passes.map((items) => items.data).flat())}`);
 
-      const items = passes as Extract<
-        TPassWorkerToMasterTaskComplete,
-        { command: typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA }
-      >[];
-      const db = await openDatabase(option);
-      const newDb = mergeDatabaseItems(db, items.map((item) => item.data).flat());
+        const items = passes as Extract<
+          TPassWorkerToMasterTaskComplete,
+          { command: typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA }
+        >[];
+        const db = await openDatabase(option);
+        const newDb = mergeDatabaseItems(db, items.map((item) => item.data).flat());
 
-      await saveDatabase(option, newDb);
+        await saveDatabase(option, newDb);
+      }
     }
 
     const fails = reply.data.filter(isFailTaskComplete);

--- a/src/cli/commands/refreshOnDatabaseSync.ts
+++ b/src/cli/commands/refreshOnDatabaseSync.ts
@@ -18,6 +18,7 @@ import summarySchemaTypes from '#modules/summarySchemaTypes';
 import { isError } from 'my-easy-fp';
 import { getDirname } from 'my-node-fp';
 import path from 'path';
+import * as tjsg from 'ts-json-schema-generator';
 import type { SetRequired } from 'type-fest';
 
 export default async function refreshOnDatabaseSync(baseOption: TRefreshSchemaBaseOption) {
@@ -74,15 +75,16 @@ export default async function refreshOnDatabaseSync(baseOption: TRefreshSchemaBa
 
     const schemaFiles = await summarySchemaFiles(project.pass, option);
     const schemaTypes = await summarySchemaTypes(project.pass, option, schemaFiles.filter);
+    const generator = tjsg.createGenerator(option.generatorOptionObject);
 
     const items = (
       await Promise.all(
         schemaTypes.map(async (targetType) => {
-          const schema = createJSONSchema(
-            targetType.filePath,
-            targetType.identifier,
-            option.generatorOptionObject,
-          );
+          const schema = createJSONSchema({
+            filePath: targetType.filePath,
+            exportedType: targetType.identifier,
+            generator,
+          });
 
           if (schema.type === 'fail') {
             return undefined;

--- a/src/cli/commands/watchNozzleCluster.ts
+++ b/src/cli/commands/watchNozzleCluster.ts
@@ -80,19 +80,6 @@ export default async function watchNozzleCluster(baseOption: TWatchSchemaBaseOpt
     throw new SchemaNozzleError(failReply.error);
   }
 
-  workers.sendAll({
-    command: CE_WORKER_ACTION.GENERATOR_OPTION_LOAD,
-  } satisfies TPickMasterToWorkerMessage<typeof CE_WORKER_ACTION.GENERATOR_OPTION_LOAD>);
-
-  reply = await workers.wait();
-
-  // master check project diagostic on worker
-  if (reply.data.some((workerReply) => workerReply.result === 'fail')) {
-    const failReplies = reply.data.filter(isFailTaskComplete);
-    const failReply = atOrThrow(failReplies, 0);
-    throw new SchemaNozzleError(failReply.error);
-  }
-
   spinner.update({ message: 'TypeScript project file loaded', channel: 'succeed' });
   spinner.update({ message: `Watch project: ${option.project}`, channel: 'info' });
   spinner.stop();

--- a/src/compilers/__tests__/compiler.tool.test.ts
+++ b/src/compilers/__tests__/compiler.tool.test.ts
@@ -1,4 +1,5 @@
 import getExportedName from '#compilers/getExportedName';
+import getJsDocTags from '#compilers/getJsDocTags';
 import getTsProject from '#compilers/getTsProject';
 import getResolvedPaths from '#configs/getResolvedPaths';
 import 'jest';
@@ -54,16 +55,22 @@ describe('getExportedName', () => {
   beforeAll(() => {
     const sourceText = `export const a = 'hello';
     export class A {}
-    export const ar = () => {};
+    export const ar () => {};
     export function ff() {}
     export interface IA {}
     export type TA = number;
-    export enum EA {}`;
+    export enum EA { A, B, C }`;
 
     data.project.createSourceFile('c1.ts', sourceText);
     data.project.createSourceFile('c2.ts', `export default [1, 2, 3]`);
     data.project.createSourceFile('c3.ts', `export default { a: '1' }`);
     data.project.createSourceFile('c4.ts', `declare module 'nozzle' {}`);
+    data.project.createSourceFile('c5.ts', `export default () => {}`);
+    data.project.createSourceFile(
+      'c6.ts',
+      `const obj = { a: 1, b: 2 }; export const { a, b } = obj;`,
+    );
+    data.project.createSourceFile('c7.ts', `export const { a, b }`);
   });
 
   test('normal', () => {
@@ -95,5 +102,76 @@ describe('getExportedName', () => {
     } catch (caught) {
       expect(caught).toBeTruthy();
     }
+  });
+
+  test('exception', () => {
+    try {
+      const d1 = data.project.getSourceFile('c5.ts')!.getExportedDeclarations();
+
+      Array.from(d1.values())
+        .flat()
+        .map((node) => getExportedName(node));
+    } catch (caught) {
+      expect(caught).toBeTruthy();
+    }
+  });
+
+  test('binding element', () => {
+    try {
+      const d1 = data.project.getSourceFile('c6.ts')!.getExportedDeclarations();
+      Array.from(d1.values())
+        .flat()
+        .map((node) => getExportedName(node));
+    } catch (caught) {
+      expect(caught).toBeTruthy();
+    }
+  });
+
+  test('object literal expression', () => {
+    try {
+      const d1 = data.project.getSourceFile('c7.ts')!.getExportedDeclarations();
+      Array.from(d1.values())
+        .flat()
+        .map((node) => getExportedName(node));
+    } catch (caught) {
+      expect(caught).toBeTruthy();
+    }
+  });
+});
+
+describe('getJsDocTags', () => {
+  beforeAll(() => {
+    const sourceText = `;
+    /** @jsdoc-1 */
+    export class T1_Class { name: string }
+
+    /** @jsdoc-2 */
+    export interface T2_Interface { name: string }
+    
+    /** @jsdoc-3 */
+    export type T3_TypeAlias = { name: string };
+
+    /** @jsdoc-4 */
+    export enum T4_Enum {
+      FIRST,
+      SECOND
+    }`;
+
+    data.project.createSourceFile('tt1.ts', sourceText);
+  });
+
+  test('all', () => {
+    const d1 = data.project.getSourceFile('tt1.ts')!.getExportedDeclarations();
+    const tags = Array.from(d1.values())
+      .flat()
+      .map((r) => getJsDocTags(r))
+      .flat();
+
+    expect(tags.map((tag) => tag.getTagName())).toEqual([
+      'jsdoc-1',
+      'jsdoc-2',
+      'jsdoc-3',
+      'jsdoc-4',
+    ]);
   });
 });

--- a/src/databases/createDatabaseItem.ts
+++ b/src/databases/createDatabaseItem.ts
@@ -54,6 +54,7 @@ export default function createDatabaseItem(
     return { ...aggregation, [exportedType.identifier]: exportedType };
   }, {});
 
+  targetSchema.$id = schema.exportedType;
   traverse(targetSchema, traverseHandle);
 
   const id = schema.exportedType;

--- a/src/modules/__tests__/schema.create.test.ts
+++ b/src/modules/__tests__/schema.create.test.ts
@@ -3,6 +3,7 @@ import getSchemaGeneratorOption from '#configs/getSchemaGeneratorOption';
 import createJSONSchema from '#modules/createJSONSchema';
 import 'jest';
 import path from 'path';
+import * as tjsg from 'ts-json-schema-generator';
 import type { AsyncReturnType } from 'type-fest';
 
 const originPath = process.env.INIT_CWD!;
@@ -29,18 +30,17 @@ beforeEach(() => {
 
 describe('createJSONSchema', () => {
   test('normal', async () => {
-    const schema = createJSONSchema(
-      path.join(data.resolvedPaths.cwd, 'I18nDto.ts'),
-      'ILanguageDto',
-      { ...data.option, schemaId: 'ILanguageDto22' },
-    );
+    const schema = createJSONSchema({
+      filePath: path.join(data.resolvedPaths.cwd, 'I18nDto.ts'),
+      exportedType: 'ILanguageDto',
+      generator: tjsg.createGenerator({ ...data.option }),
+    });
 
     if (schema.type === 'fail') {
       throw schema.fail;
     }
 
     expect(schema.pass.schema).toMatchObject({
-      $id: 'ILanguageDto22',
       $schema: 'http://json-schema.org/draft-07/schema#',
       type: 'object',
       properties: {
@@ -60,11 +60,11 @@ describe('createJSONSchema', () => {
   });
 
   test('exception', async () => {
-    const schema = createJSONSchema(
-      path.join(data.resolvedPaths.cwd, 'I18nDto.ts'),
-      'ILanguageDto2',
-      { ...data.option, skipTypeCheck: false },
-    );
+    const schema = createJSONSchema({
+      filePath: path.join(data.resolvedPaths.cwd, 'I18nDto.ts'),
+      exportedType: 'ILanguageDto2',
+      generator: tjsg.createGenerator({ ...data.option, skipTypeCheck: false }),
+    });
 
     expect(schema.type).toEqual('fail');
   });

--- a/src/modules/__tests__/schema.record.test.ts
+++ b/src/modules/__tests__/schema.record.test.ts
@@ -8,6 +8,7 @@ import getData from '#tools/__tests__/test-tools/getData';
 import 'jest';
 import 'jsonc-parser';
 import path from 'path';
+import * as tjsg from 'ts-json-schema-generator';
 import * as tsm from 'ts-morph';
 import type { AsyncReturnType, LastArrayElement } from 'type-fest';
 
@@ -50,11 +51,11 @@ beforeEach(async () => {
 
 describe('createDatabaseItem', () => {
   test('without definitions', async () => {
-    const schema = createJSONSchema(
-      path.join(originPath, 'examples', 'CE_MAJOR.ts'),
-      'CE_MAJOR',
-      data.generatorOption,
-    );
+    const schema = createJSONSchema({
+      filePath: path.join(originPath, 'examples', 'CE_MAJOR.ts'),
+      exportedType: 'CE_MAJOR',
+      option: data.generatorOption,
+    });
 
     if (schema.type !== 'pass') {
       throw new Error('schema generation fail');
@@ -75,11 +76,11 @@ describe('createDatabaseItem', () => {
   });
 
   test('with definitions', async () => {
-    const schema = createJSONSchema(
-      path.join(originPath, 'examples', 'IStudentDto.ts'),
-      'IStudentDto',
-      data.generatorOption,
-    );
+    const schema = createJSONSchema({
+      filePath: path.join(originPath, 'examples', 'IStudentDto.ts'),
+      exportedType: 'IStudentDto',
+      generator: tjsg.createGenerator(data.generatorOption),
+    });
 
     if (schema.type !== 'pass') {
       throw new Error('schema generation fail');
@@ -101,11 +102,11 @@ describe('createDatabaseItem', () => {
   });
 
   test('import', async () => {
-    const schema = createJSONSchema(
-      path.join(originPath, 'examples', 'ISlackMessage.ts'),
-      'ISlackMessageBody',
-      data.generatorOption,
-    );
+    const schema = createJSONSchema({
+      filePath: path.join(originPath, 'examples', 'ISlackMessage.ts'),
+      exportedType: 'ISlackMessageBody',
+      option: data.generatorOption,
+    });
 
     if (schema.type !== 'pass') {
       throw new Error('schema generation fail');

--- a/src/modules/createJSONSchema.ts
+++ b/src/modules/createJSONSchema.ts
@@ -4,33 +4,47 @@ import { isError } from 'my-easy-fp';
 import { fail, pass, type PassFailEither } from 'my-only-either';
 import * as tjsg from 'ts-json-schema-generator';
 
-export default function createJSONSchema(
-  filePath: string,
-  exportedType: string,
-  generatorOption: tjsg.Config,
-): PassFailEither<Error, { filePath: string; exportedType: string; schema: JSONSchema7 }> {
-  try {
-    const option: tjsg.Config = {
-      ...generatorOption,
-      path: filePath,
-      type: exportedType,
-      schemaId:
-        generatorOption.schemaId == null || generatorOption.schemaId === ''
-          ? exportedType
-          : generatorOption.schemaId,
+type TCreateJSONSchemaArgs =
+  | {
+      filePath: string;
+      exportedType: string;
+      option: tjsg.Config;
+    }
+  | {
+      filePath: string;
+      exportedType: string;
+      generator: tjsg.SchemaGenerator;
     };
 
-    const generator = tjsg.createGenerator(option);
+function getGenerator(args: TCreateJSONSchemaArgs) {
+  if ('option' in args) {
+    const option: tjsg.Config = {
+      ...args.option,
+      path: args.filePath,
+      type: args.exportedType,
+    };
 
-    const schema: JSONSchema7 = generator.createSchema(exportedType);
+    return tjsg.createGenerator(option);
+  }
+
+  return args.generator;
+}
+
+export default function createJSONSchema(
+  args: TCreateJSONSchemaArgs,
+): PassFailEither<Error, { filePath: string; exportedType: string; schema: JSONSchema7 }> {
+  try {
+    const generator = getGenerator(args);
+
+    const schema: JSONSchema7 = generator.createSchema(args.exportedType);
 
     return pass({
-      filePath,
-      exportedType,
+      filePath: args.filePath,
+      exportedType: args.exportedType,
       schema,
     });
   } catch (caught) {
     const err = isError(caught, new Error('unknown error raised'));
-    return fail(new CreateJSONSchemaError(filePath, exportedType, err.message));
+    return fail(new CreateJSONSchemaError(args.filePath, args.exportedType, err.message));
   }
 }

--- a/src/workers/__tests__/work.emitter.exit.test.ts
+++ b/src/workers/__tests__/work.emitter.exit.test.ts
@@ -2,22 +2,16 @@ import { CE_WORKER_ACTION } from '#workers/interfaces/CE_WORKER_ACTION';
 import NozzleEmitter from '#workers/NozzleEmitter';
 import 'jest';
 
-beforeAll(() => {
-  jest.spyOn(process, 'exit').mockImplementation((_code?: number | undefined) => {
-    throw new Error('Exit triggered');
-  });
-
-  jest.spyOn(process, 'send').mockImplementation((_data: unknown) => {
-    return true;
-  });
-});
-
 afterAll(() => {
   jest.clearAllMocks();
 });
 
 describe('WorkEmitter - terminate', () => {
   test('terminate', () => {
+    jest.spyOn(process, 'exit').mockImplementationOnce((_code?: number | undefined) => {
+      throw new Error('Exit triggered');
+    });
+
     try {
       NozzleEmitter.terminate(0);
     } catch (caught) {
@@ -26,6 +20,10 @@ describe('WorkEmitter - terminate', () => {
   });
 
   test('terminate - undefined', () => {
+    jest.spyOn(process, 'exit').mockImplementationOnce((_code?: number | undefined) => {
+      throw new Error('Exit triggered');
+    });
+
     try {
       NozzleEmitter.terminate();
     } catch (caught) {
@@ -34,6 +32,10 @@ describe('WorkEmitter - terminate', () => {
   });
 
   test('terminate - emit', () => {
+    jest.spyOn(process, 'exit').mockImplementationOnce((_code?: number | undefined) => {
+      throw new Error('Exit triggered');
+    });
+
     try {
       const w = new NozzleEmitter();
       w.emit(CE_WORKER_ACTION.TERMINATE);

--- a/src/workers/__tests__/work.emitter.schema.ts
+++ b/src/workers/__tests__/work.emitter.schema.ts
@@ -1,0 +1,256 @@
+import getResolvedPaths from '#configs/getResolvedPaths';
+import getSchemaGeneratorOption from '#configs/getSchemaGeneratorOption';
+import type TAddSchemaOption from '#configs/interfaces/TAddSchemaOption';
+import * as odb from '#databases/openDatabase';
+import * as ffp from '#modules/getSchemaFilterFilePath';
+import type IDatabaseItem from '#modules/interfaces/IDatabaseItem';
+import * as env from '#modules/__tests__/env';
+import getData from '#tools/__tests__/test-tools/getData';
+import { CE_WORKER_ACTION } from '#workers/interfaces/CE_WORKER_ACTION';
+import type { TPickMasterToWorkerMessage } from '#workers/interfaces/TMasterToWorkerMessage';
+import NozzleEmitter from '#workers/NozzleEmitter';
+import 'jest';
+import path from 'path';
+import * as tjsg from 'ts-json-schema-generator';
+import * as tsm from 'ts-morph';
+
+const originPath = process.env.INIT_CWD!;
+const data: {
+  resolvedPaths: ReturnType<typeof getResolvedPaths>;
+  project: tsm.Project;
+  option: TAddSchemaOption;
+  generator: tjsg.SchemaGenerator;
+} = {} as any;
+
+beforeAll(async () => {
+  data.project = new tsm.Project({
+    tsConfigFilePath: path.join(originPath, 'examples', 'tsconfig.json'),
+  });
+  data.option = {
+    ...env.addCmdOption,
+  };
+  data.option.generatorOptionObject = await getSchemaGeneratorOption(data.option);
+  data.generator = tjsg.createGenerator({
+    ...data.option.generatorOptionObject,
+    path: path.join(originPath, 'examples', 'CE_MAJOR.ts'),
+    type: '*',
+  });
+});
+
+beforeEach(() => {
+  process.env.INIT_CWD = path.join(originPath, 'examples');
+  data.resolvedPaths = getResolvedPaths({
+    project: path.join(originPath, 'examples', 'tsconfig.json'),
+    output: path.join(originPath, 'examples'),
+  });
+  data.option = { ...data.option, ...data.resolvedPaths };
+
+  jest.spyOn(process, 'exit').mockImplementationOnce((_code?: number | undefined) => {
+    throw new Error('Exit triggered');
+  });
+
+  jest.spyOn(process, 'send').mockImplementationOnce((_data: unknown) => {
+    return true;
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('WorkEmitter - schema', () => {
+  test('summarySchemaFiles', async () => {
+    const w = new NozzleEmitter();
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    await w.workerSummarySchemaFiles();
+
+    jest.spyOn(w, 'workerSummarySchemaFiles').mockImplementationOnce(() => Promise.reject());
+    w.emit(CE_WORKER_ACTION.SUMMARY_SCHEMA_FILES);
+  });
+
+  test('summarySchemaTypes', async () => {
+    const w = new NozzleEmitter();
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    await w.workerSummarySchemaTypes();
+
+    jest.spyOn(w, 'workerSummarySchemaTypes').mockImplementationOnce(() => Promise.reject());
+    w.emit(CE_WORKER_ACTION.SUMMARY_SCHEMA_TYPES);
+  });
+
+  test('summarySchemaFileType', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+    w.project = data.project;
+
+    await w.workerSummarySchemaFileType();
+
+    jest.spyOn(w, 'workerSummarySchemaFileType').mockImplementationOnce(() => Promise.reject());
+    w.emit(CE_WORKER_ACTION.SUMMARY_SCHEMA_FILE_TYPE);
+  });
+
+  test('loadDatabase', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+    w.project = data.project;
+    await w.loadDatabase();
+
+    jest.spyOn(w, 'loadDatabase').mockImplementationOnce(() => Promise.reject());
+    w.emit(CE_WORKER_ACTION.LOAD_DATABASE);
+  });
+
+  test('loadDatabase - exception', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+
+    jest.spyOn(ffp, 'default').mockImplementationOnce(() => Promise.resolve(undefined));
+    jest.spyOn(odb, 'default').mockImplementationOnce(() => Promise.resolve({}));
+
+    w.project = data.project;
+    await w.loadDatabase();
+  });
+
+  test('loadDatabase - db', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+    const dbData = await getData<Record<string, IDatabaseItem>>(
+      path.join(__dirname, 'data/001.json'),
+    );
+
+    jest.spyOn(ffp, 'default').mockImplementationOnce(() => Promise.resolve(undefined));
+    jest.spyOn(odb, 'default').mockImplementationOnce(() => Promise.resolve(dbData));
+
+    w.project = data.project;
+    await w.loadDatabase();
+  });
+
+  test('createJsonSchema - mapped access + call', async () => {
+    const w = new NozzleEmitter();
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    await w.createJsonSchema({
+      filePath: path.join(w.option!.cwd, 'IProfessorDto.ts'),
+      exportedType: 'IProfessorDto',
+    });
+  });
+
+  test('createJsonSchema - mapped access - call', async () => {
+    const w = new NozzleEmitter({ generator: data.generator });
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    await w.createJsonSchema({
+      filePath: path.join(w.option!.cwd, 'IProfessorDto.ts'),
+      exportedType: 'IProfessorDto',
+    });
+  });
+
+  test('createJsonSchema - with root type + emit', async () => {
+    const w = new NozzleEmitter();
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    const payload: TPickMasterToWorkerMessage<typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA>['data'] =
+      {
+        filePath: path.join(data.option.cwd, 'IReqReadStudentDto.ts'),
+        exportedType: 'IReqReadStudentQuerystring',
+      };
+    w.emit(CE_WORKER_ACTION.CREATE_JSON_SCHEMA, payload);
+  });
+
+  test('createJsonSchema - with root type + emit exception', async () => {
+    const w = new NozzleEmitter();
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    const payload: TPickMasterToWorkerMessage<typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA>['data'] =
+      {
+        filePath: path.join(w.option!.cwd, 'IProfessorDto.ts'),
+        exportedType: 'IProfessorDto',
+      };
+
+    jest.spyOn(w, 'createJsonSchema').mockImplementationOnce(() => Promise.reject());
+    w.emit(CE_WORKER_ACTION.CREATE_JSON_SCHEMA, payload);
+  });
+
+  test('createJsonSchema without root type', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+    w.project = data.project;
+
+    await w.createJsonSchema({
+      filePath: path.join(w.option!.cwd, 'CE_MAJOR.ts'),
+      exportedType: 'CE_MAJOR',
+    });
+  });
+
+  test('createJsonSchema - fail', async () => {
+    const w = new NozzleEmitter();
+    w.project = data.project;
+    w.loadOption({ option: data.option });
+
+    await w.createJsonSchema({
+      filePath: path.join(w.option!.cwd, 'IProfessorDto.ts'),
+      exportedType: 'IProfessorDto33',
+    });
+  });
+
+  test('createJsonSchemaBulk - call', async () => {
+    const w = new NozzleEmitter({ generator: data.generator });
+    w.loadOption({ option: data.option });
+    w.project = data.project;
+
+    await w.createJsonSchemaBulk([
+      {
+        filePath: path.join(data.option.cwd, 'IReqReadStudentDto.ts'),
+        exportedType: 'IReqReadStudentQuerystring',
+      },
+      {
+        filePath: path.join(data.option.cwd, 'IReqReadStudentDto.ts'),
+        exportedType: 'IReqReadStudentParam',
+      },
+    ]);
+  });
+
+  test('createJsonSchemaBulk - emit', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+    w.project = data.project;
+
+    const payload: TPickMasterToWorkerMessage<
+      typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA_BULK
+    >['data'] = [
+      {
+        filePath: path.join(data.option.cwd, 'IReqReadStudentDto.ts'),
+        exportedType: 'IReqReadStudentParam',
+      },
+      {
+        filePath: path.join(data.option.cwd, 'IReqReadStudentDto.ts'),
+        exportedType: 'IReqReadStudentQuerystring',
+      },
+      {
+        filePath: path.join(w.option!.cwd, 'IProfessorDto.ts'),
+        exportedType: 'IProfessorDto',
+      },
+    ];
+
+    w.emit(CE_WORKER_ACTION.CREATE_JSON_SCHEMA_BULK, payload);
+  });
+
+  test('createJsonSchemaBulk - call either fail', async () => {
+    const w = new NozzleEmitter();
+    w.loadOption({ option: data.option });
+    w.project = data.project;
+
+    await w.createJsonSchemaBulk([
+      {
+        filePath: path.join(data.option.cwd, 'IProfessorDto_raise_fail.ts'),
+        exportedType: 'IProfessorDto',
+      },
+    ]);
+  });
+});

--- a/src/workers/__tests__/work.emitter.watch.test.ts
+++ b/src/workers/__tests__/work.emitter.watch.test.ts
@@ -1,4 +1,6 @@
 import getResolvedPaths from '#configs/getResolvedPaths';
+import getSchemaGeneratorOption from '#configs/getSchemaGeneratorOption';
+import type TAddSchemaOption from '#configs/interfaces/TAddSchemaOption';
 import { CE_WATCH_EVENT } from '#modules/interfaces/CE_WATCH_EVENT';
 import * as env from '#modules/__tests__/env';
 import { CE_WORKER_ACTION } from '#workers/interfaces/CE_WORKER_ACTION';
@@ -11,12 +13,18 @@ const originPath = process.env.INIT_CWD!;
 const data: {
   resolvedPaths: ReturnType<typeof getResolvedPaths>;
   project: tsm.Project;
+  option: TAddSchemaOption;
 } = {} as any;
 
-beforeAll(() => {
+beforeAll(async () => {
   data.project = new tsm.Project({
     tsConfigFilePath: path.join(originPath, 'examples', 'tsconfig.json'),
   });
+  data.option = {
+    ...env.addCmdOption,
+    ...data.resolvedPaths,
+  };
+  data.option.generatorOptionObject = await getSchemaGeneratorOption(data.option);
 });
 
 beforeEach(() => {
@@ -25,6 +33,11 @@ beforeEach(() => {
     project: path.join(originPath, 'examples', 'tsconfig.json'),
     output: path.join(originPath, 'examples'),
   });
+
+  data.option = {
+    ...data.option,
+    ...data.resolvedPaths,
+  };
 
   jest.spyOn(process, 'exit').mockImplementationOnce((_code?: number | undefined) => {
     throw new Error('Exit triggered');
@@ -42,24 +55,24 @@ afterEach(() => {
 describe('WorkEmitter - watch', () => {
   test('add', async () => {
     const w = new NozzleEmitter();
-    w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+    w.loadOption({ option: data.option });
     w.project = data.project;
 
     await w.watchSourceFileAdd({
       kind: CE_WATCH_EVENT.ADD,
-      filePath: path.join(w.option.cwd, 'IStudentDto.ts'),
+      filePath: path.join(w.option!.cwd, 'IStudentDto.ts'),
     });
 
     w.emit(CE_WORKER_ACTION.WATCH_SOURCE_FILE_ADD, {
       kind: CE_WATCH_EVENT.ADD,
-      filePath: path.join(w.option.cwd, 'IStudentDto.ts'),
+      filePath: path.join(w.option!.cwd, 'IStudentDto.ts'),
     });
   });
 
   test('add - exception', async () => {
     try {
       const w = new NozzleEmitter();
-      w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+      w.loadOption({ option: data.option });
       w.project = data.project;
 
       await w.watchSourceFileAdd({
@@ -73,24 +86,24 @@ describe('WorkEmitter - watch', () => {
 
   test('change', async () => {
     const w = new NozzleEmitter();
-    w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+    w.loadOption({ option: data.option });
     w.project = data.project;
 
     await w.watchSourceFileChange({
       kind: CE_WATCH_EVENT.CHANGE,
-      filePath: path.join(w.option.cwd, 'IStudentDto.ts'),
+      filePath: path.join(data.option.cwd, 'IStudentDto.ts'),
     });
 
     w.emit(CE_WORKER_ACTION.WATCH_SOURCE_FILE_CHANGE, {
       kind: CE_WATCH_EVENT.CHANGE,
-      filePath: path.join(w.option.cwd, 'IStudentDto.ts'),
+      filePath: path.join(data.option.cwd, 'IStudentDto.ts'),
     });
   });
 
   test('change - not found', async () => {
     try {
       const w = new NozzleEmitter();
-      w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+      w.loadOption({ option: data.option });
       w.project = data.project;
 
       await w.watchSourceFileChange({
@@ -105,7 +118,7 @@ describe('WorkEmitter - watch', () => {
   test('change - exception', async () => {
     try {
       const w = new NozzleEmitter();
-      w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+      w.loadOption({ option: data.option });
       w.project = data.project;
 
       jest.spyOn(w.project, 'getSourceFile').mockImplementationOnce(() => {
@@ -123,24 +136,24 @@ describe('WorkEmitter - watch', () => {
 
   test('unlink', async () => {
     const w = new NozzleEmitter();
-    w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+    w.loadOption({ option: data.option });
     w.project = data.project;
 
     await w.watchSourceFileUnlink({
       kind: CE_WATCH_EVENT.UNLINK,
-      filePath: path.join(w.option.cwd, 'IStudentDto.ts'),
+      filePath: path.join(data.option.cwd, 'IStudentDto.ts'),
     });
 
     w.emit(CE_WORKER_ACTION.WATCH_SOURCE_FILE_UNLINK, {
       kind: CE_WATCH_EVENT.UNLINK,
-      filePath: path.join(w.option.cwd, 'IStudentDto.ts'),
+      filePath: path.join(data.option.cwd, 'IStudentDto.ts'),
     });
   });
 
   test('unlink - not found', async () => {
     try {
       const w = new NozzleEmitter();
-      w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+      w.loadOption({ option: data.option });
       w.project = data.project;
 
       await w.watchSourceFileUnlink({
@@ -155,7 +168,7 @@ describe('WorkEmitter - watch', () => {
   test('unlink - exception', async () => {
     try {
       const w = new NozzleEmitter();
-      w.option = { ...env.addCmdOption, ...data.resolvedPaths };
+      w.loadOption({ option: data.option });
       w.project = data.project;
 
       jest.spyOn(w.project, 'getSourceFile').mockImplementationOnce(() => {

--- a/src/workers/interfaces/CE_WORKER_ACTION.ts
+++ b/src/workers/interfaces/CE_WORKER_ACTION.ts
@@ -8,7 +8,6 @@ export const CE_WORKER_ACTION = {
   SUMMARY_SCHEMA_FILE_TYPE: 'summary-schema-file-type',
   LOAD_DATABASE: 'load-database',
 
-  GENERATOR_OPTION_LOAD: 'generator-option-load',
   CREATE_JSON_SCHEMA: 'create-json-schema',
   CREATE_JSON_SCHEMA_BULK: 'create-json-schema-bulk',
 

--- a/src/workers/interfaces/TMasterToWorkerMessage.ts
+++ b/src/workers/interfaces/TMasterToWorkerMessage.ts
@@ -19,7 +19,6 @@ type TMasterToWorkerMessage =
   | { command: typeof CE_WORKER_ACTION.SUMMARY_SCHEMA_FILE_TYPE }
   | { command: typeof CE_WORKER_ACTION.LOAD_DATABASE }
   // schema command
-  | { command: typeof CE_WORKER_ACTION.GENERATOR_OPTION_LOAD }
   | {
       command: typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA;
       data: { filePath: string; exportedType: string };

--- a/src/workers/interfaces/TWorkerToMasterMessage.ts
+++ b/src/workers/interfaces/TWorkerToMasterMessage.ts
@@ -1,7 +1,6 @@
 import type IDatabaseItem from '#modules/interfaces/IDatabaseItem';
 import type { CE_MASTER_ACTION } from '#workers/interfaces/CE_MASTER_ACTION';
 import type { CE_WORKER_ACTION } from '#workers/interfaces/CE_WORKER_ACTION';
-import type * as tjsg from 'ts-json-schema-generator';
 
 export type TPassWorkerToMasterTaskComplete =
   | {
@@ -27,12 +26,6 @@ export type TPassWorkerToMasterTaskComplete =
       result: 'pass';
       id: number;
       data?: undefined;
-    }
-  | {
-      command: typeof CE_WORKER_ACTION.GENERATOR_OPTION_LOAD;
-      result: 'pass';
-      id: number;
-      data: tjsg.Config;
     }
   | {
       command: typeof CE_WORKER_ACTION.CREATE_JSON_SCHEMA;


### PR DESCRIPTION
* re-use schema generator: schema generator have cache, now each worker use schema generator re-use and applied schema generator cache
* fix timeout error don't handle
* enhance testcase
  * migrate testcase
  * add more testcase
* remove unused message, action
  * generator option load action removed
* schema id `$id` add via schema-nozzle: as-is add `$id` using schema generator